### PR TITLE
(MAINT) Fix hero h1 overflow on mobile

### DIFF
--- a/assets/css/theme.scss
+++ b/assets/css/theme.scss
@@ -176,6 +176,13 @@ th, td {
 
 .hero h1 {
     font-size:2.5em;
+
+    @media screen and (max-width: 1024px) {
+        font-size: 2.25em;
+    }
+    @media screen and (max-width: 767px) {
+        font-size: 2em;
+    }
 }
 .section-title h2 {
 	font-weight:700;


### PR DESCRIPTION
Prior to this change, the hero heading on mobile would butt up against the side of the screen. This change reduces the size of the h1 on smaller screens and keeps the text from doing so when the screen is at least 380px wide, which should cover most devices.